### PR TITLE
intern results from retriever ls

### DIFF
--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -124,16 +124,16 @@ download = function(dataset, path='.', log_dir=NULL) {
     system(cmd)
 }
 
-#' Display a list all available dataset scripts.
+#' Name all available dataset scripts.
 #'
 #' Additional information on the available datasets can be found at http://ecodataretriever.org/available-data.html
 #' 
-#' @return returns the log of the available datasets for download
+#' @return returns a character vector with the available datasets for download
 #' @export
 #' @examples 
 #' ecoretriever::datasets()
 datasets = function(){
-  system('retriever ls') 
+  system('retriever ls', intern = TRUE) 
 }
 
 .onAttach = function(...) {


### PR DESCRIPTION
The `datasets` function currently has some behavior that makes it hard to work with from within R.

` length(datasets()) # returns 1`
`class(datasets()) # returns "integer"`

I made a small change that captures the output from `retriever ls` and makes it available to R instead of printing it.