### PR TITLE
Patch the get_updates function

### DIFF
--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -168,7 +168,7 @@ get_updates = function() {
 #' @export
 print.update_log = function(x, ...) {
     # clean up and print the update log output
-    object = strsplit(paste(object, collapse = ' ; '), 'Downloading script: ')
+    object = strsplit(paste(x, collapse = ' ; '), 'Downloading script: ')
     object = sort(sapply(strsplit(object[[1]][-1], ' ; '), 
                        function(x) x[[1]][1]))
     object[1] = paste('Downloaded scripts:', object[1])

--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -167,12 +167,17 @@ get_updates = function() {
 
 #' @export
 print.update_log = function(x, ...) {
-    # clean up and print the update log output
-    object = strsplit(paste(x, collapse = ' ; '), 'Downloading script: ')
-    object = sort(sapply(strsplit(object[[1]][-1], ' ; '), 
+    if (length(x) == 0) {
+        cat('No scripts downloaded')
+    } 
+    else {
+        # clean up and print the update log output
+        object = strsplit(paste(x, collapse = ' ; '), 'Downloading script: ')
+        object = sort(sapply(strsplit(object[[1]][-1], ' ; '), 
                        function(x) x[[1]][1]))
-    object[1] = paste('Downloaded scripts:', object[1])
-    cat(object, fill=TRUE, sep=', ')
+        object[1] = paste('Downloaded scripts:', object[1])
+        cat(object, fill=TRUE, sep=', ')
+    }
 }
 
 .onAttach = function(...) {


### PR DESCRIPTION
I detected that the function `get_updates` was producing errors because 1) a last minute change to the argument definition of this function was not properly implemented, and 2) sometimes the retriever does not download new scripts and thus returns a log without any text. These two commits solve these two problems. If no scripts are downloaded this is simply relayed to the user. 