### PR TITLE
Fix --subdir download by removing extra argument

### DIFF
--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -118,7 +118,7 @@ fetch = function(dataset, quiet=TRUE){
 #' }
 download = function(dataset, path='.', sub_dir=FALSE, log_dir=NULL) {
     if (sub_dir)
-        cmd = paste('retriever download', dataset, dataset, '-p', path, '--subdir')
+        cmd = paste('retriever download', dataset, '-p', path, '--subdir')
     else 
         cmd = paste('retriever download', dataset, '-p', path)
     if (!is.null(log_dir)) {


### PR DESCRIPTION
An extra copy of the `dataset` argument had crept into the sub_dir clause
of the download function. This result in errors if the sub_dir option is
used.