### PR TITLE
Accomodate new retriever naming conventions in fetch

### DIFF
--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -95,7 +95,8 @@ fetch = function(dataset, quiet=TRUE){
   else
     install(dataset, connection='csv', data_dir=temp_path)
   files = dir(temp_path)
-  files = files[grep(dataset, files)]
+  dataset_underscores = gsub("-", "_", dataset) #retriever converts - in dataset name to _ in filename
+  files = files[grep(dataset_underscores, files)]
   out = vector('list', length(files))
   list_names = sub('.csv', '', files)
   list_names = sub(paste(dataset, '_', sep=''), '', list_names)


### PR DESCRIPTION
The soon to be released version 2.0 of the core retriever has moved to using dataset
names that include words separated by `-` in line with the datapackage spec. These
names are then converted to `_` for compatibility with some database managment systems.
This resulted in `fetch()` not finding the temporary files it had downloaded because
the dataset name and relevant piece of the file name didn't match precisely. This
converts the dataset name to `_` when matching.

Fixes #75.