### PR TITLE
Don't change the class or return the update log

### DIFF
--- a/R/ecoretriever.R
+++ b/R/ecoretriever.R
@@ -165,10 +165,8 @@ datasets = function(){
 get_updates = function() {
     writeLines(strwrap('Please wait while the retriever updates its scripts, ...'))
     update_log = run_cli('retriever update', intern=TRUE, ignore.stdout=FALSE,
-                        ignore.stderr=TRUE)
-    writeLines(strwrap('The retriever scripts are up-to-date with the most recent official release!'))
-    class(update_log) = "update_log"
-    return(update_log)
+                         ignore.stderr=TRUE)
+    writeLines(strwrap(update_log[3]))
 }
 
 #' @export


### PR DESCRIPTION
Get updates was storing the output of running `retriever update`, setting
it's class to `update_log` and returning this output. The current output
from `retriever update` isn't genearlly useful, it's mostly just a progress
bar, and for some reason changing it's class was creating an error (see #82)
so this just change just prints the third value from `update_log`, which
indicates that the update is complete.

Fixes #82.