### PR TITLE
Adding Shawn Taylor as an author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,8 @@ Version: 0.3.0
 Date: 2015-11-18
 Authors@R: c(person("Daniel", "McGlinn", role = c("aut", "cre"),
     email = "danmcglinn@gmail.com"),
+    person("Shawn", "Taylor", role = "aut",
+    email = "shawntaylor@weecology.org"),
     person("Ethan", "White", role = "aut",
     email = "ethan@weecology.org"))
 BugReports: https://github.com/ropensci/ecoretriever/issues


### PR DESCRIPTION
As suggested by Dan McGlinn (and I agree), Shawn's contribution of solving
the Anaconda problem merits being added as an author.